### PR TITLE
add default-j{re,dk} package and path

### DIFF
--- a/data/pycharm/debian/control.in
+++ b/data/pycharm/debian/control.in
@@ -3,7 +3,7 @@ Section: devel
 Version: VERSION
 Maintainer: Andreas Bader <Development@Geekparadise.de>
 Architecture: all
-Depends: openjdk-8-jre |openjdk-7-jre | sun-java6-jre | openjdk-6-jre | openjdk-7-jdk | sun-java6-jdk | openjdk-6-jdk | ibm-j2sdk1.7, python | python3, debconf
+Depends: default-jdk | default-jre | openjdk-8-jre |openjdk-7-jre | sun-java6-jre | openjdk-6-jre | openjdk-7-jdk | sun-java6-jdk | openjdk-6-jdk | ibm-j2sdk1.7, python | python3, debconf
 Conflicts: pycharm-OTHER_EDITION, pycharm-OTHER_EDITION2, pycharm-EDITION2
 Description: The Most Intelligent Python IDE
 

--- a/data/pycharm/start.sh
+++ b/data/pycharm/start.sh
@@ -2,6 +2,7 @@
 
 
 paths="
+/usr/lib/jvm/default-java
 /usr/lib/jvm/java-8-oracle
 /usr/lib/jvm/java-8-openjdk
 /usr/lib/jvm/java-8-openjdk/jre


### PR DESCRIPTION
This patch helps with the detection of the installed java version for dpkg and starting the IDE after install.